### PR TITLE
[refactor] Optional Anti Pattern refactor

### DIFF
--- a/src/main/java/kr/co/talk/domain/chatroom/service/ChatService.java
+++ b/src/main/java/kr/co/talk/domain/chatroom/service/ChatService.java
@@ -184,10 +184,6 @@ public class ChatService {
         user.activeFlagOn(false);
     }
 
-    public boolean userStatus(long userId, long roomId) {
-        ChatroomUsers user = usersRepository.findChatroomUsersByChatroomIdAndUserId(roomId, userId);
-        return user.isActiveFlag();
-    }
 
     private boolean allChatroomUsersActive(List<ChatroomUsers> chatroomUsers) {
         return chatroomUsers.stream().allMatch(ChatroomUsers::isActiveFlag);

--- a/src/main/java/kr/co/talk/global/config/websocket/SocketEventListener.java
+++ b/src/main/java/kr/co/talk/global/config/websocket/SocketEventListener.java
@@ -51,13 +51,16 @@ public class SocketEventListener {
             sessionMap.remove(headerAccessor.getSessionId());
         }
 
-        Optional<Object> userIdOpt = Optional.ofNullable(headerAccessor.getSessionAttributes().get("userId"));
-        Optional<Object> roomIdOpt = Optional.ofNullable(headerAccessor.getSessionAttributes().get("roomId"));
-        if (userIdOpt.isPresent() && roomIdOpt.isPresent()) {
-            long userId = (Long) userIdOpt.get();
-            long roomId = (Long) roomIdOpt.get();
+        long userId = Optional.ofNullable((Long) headerAccessor.getSessionAttributes().get("userId"))
+                .map(Long.class::cast)
+                .orElse(-1L);
+
+        long roomId = Optional.ofNullable((Long) headerAccessor.getSessionAttributes().get("roomId"))
+                .map(Long.class::cast)
+                .orElse(-1L);
+
+        if (userId != -1L && roomId != -1L) {
             chatService.disconnectUserSetFalse(userId, roomId);
-            log.info("verify the user changed to false :: {}", chatService.userStatus(userId, roomId));
         }
 
         log.info("Web socket session closed. Message : [{}]", event.getMessage());


### PR DESCRIPTION
[ 올바른 Optional 사용법 가이드 ]

+ Optional 변수에 Null을 할당하지 말아라

+ 값이 없을 때 Optional.orElseX()로 기본 값을 반환하라

+ 단순히 값을 얻으려는 목적으로만 Optional을 사용하지 마라

+ 생성자, 수정자, 메소드 파라미터 등으로 Optional을 넘기지 마라

+ Collection의 경우 Optional이 아닌 빈 Collection을 사용하라

+ 반환 타입으로만 사용하라


이전 handleWebSocketDisConnectListener 메서드에서 isPresent()로 검사하고 get()으로 값을 꺼냈는데 이 방법보다는,

Optional.orElseX()를 사용하여 **-1L 라는 기본값을 반환** 하도록 하였습니다.

```java
if (userIdOpt.isPresent() && roomIdOpt.isPresent()) {
            long userId = (Long) userIdOpt.get();
            long roomId = (Long) roomIdOpt.get();
...
``` 
기존 isPresent() get() 메서드를

```java
if (userId != -1L && roomId != -1L) 
...
``` 

해당 if문으로 수정하였습니다.